### PR TITLE
Wait for le scan to stop before connecting to device

### DIFF
--- a/lib/bbc-microbit-io.js
+++ b/lib/bbc-microbit-io.js
@@ -137,21 +137,27 @@ BBCMicrobitIO.prototype.digitalRead = function(pin, handler) {
 BBCMicrobitIO.prototype._onDiscover = function(microbit) {
   debug('on discover', microbit);
 
-  this._microbit = microbit;
+  //Certain Intel BT Chipsets seem to require a scan stop before connections are allowed, otherwise they'll throw a: Connection Rejected due to Limited Resources 
+  BBCMicrobit.stopScanning(() => {
+    this._microbit = microbit;
 
-  this._microbit.on('pinDataChange', this._onPinDataChange.bind(this));
+    this._microbit.on('pinDataChange', this._onPinDataChange.bind(this));
 
-  this._microbit.once('disconnect', function() {
-    this.emit('disconnect');
-  }.bind(this));
-
-  this._microbit.connectAndSetUp(function() {
-    this.emit('connect');
-
-    this._microbit.subscribePinData(function() {
-      this.emit('ready');
+    this._microbit.once('disconnect', function() {
+      this.emit('disconnect');
     }.bind(this));
-  }.bind(this));
+
+    this._microbit.connectAndSetUp(function(error) {
+      if (error) {
+        console.error(error);
+      }
+      this.emit('connect');    
+        this._microbit.subscribePinData(function() {
+          this.emit('ready');
+        }.bind(this));
+      
+    }.bind(this));
+  });
 };
 
 BBCMicrobitIO.prototype._onPinDataChange = function(pin, value) {


### PR DESCRIPTION
There seems to be a bug in certain Intel BT chipsets which require a LE device scan to be stopped before being able to connect to a device.

Discovered in this issue: https://github.com/sandeepmistry/node-bbc-microbit-io/issues/1